### PR TITLE
Error rework

### DIFF
--- a/govyn/app.py
+++ b/govyn/app.py
@@ -8,7 +8,7 @@ from starlette.types import ASGIApp
 
 from .auth import AuthBackend, AuthMiddleware
 from .endpoint import make_endpoint
-from .errors import HTTPError, JSONErrorMiddleware, http_error_handler
+from .errors import JSONErrorMiddleware
 from .metrics import MetricsMiddleware, MetricsRegistry
 from .openapi import openapi_app
 from .route_def import make_route_def
@@ -62,13 +62,6 @@ def create_app(
 			for r in route_defs
 		],
 		middleware = middleware,
-		# HTTPErrors are derived from HTTPException types.
-		# As such, they need to be handled in the built-in ErrorMiddleware via an
-		# excpetion handler, as ErrorMiddleware has higher precedence than custom
-		# middlewares (such as our JSONMiddleware).
-		exception_handlers={
-			HTTPError: http_error_handler
-		}
 	)
 
 	health_app = Starlette(

--- a/govyn/auth.py
+++ b/govyn/auth.py
@@ -34,7 +34,7 @@ class AuthMiddleware(BaseHTTPMiddleware):
 			principal = await self.auth_backend.resolve_principal(req)
 
 		if principal is None:
-			return Unauthorised('authentication failed').as_response()
+			raise Unauthorised('authentication failed')
 
 		req.state.principal = principal
 		return await call_next(req)

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
 	},
 	zip_safe = False,
 	install_requires = [
-		'starlette >= 0.14',
+		'starlette >= 0.14, < 0.16',
 		'uvicorn >= 0.13',
 		'dacite >= 1.5.1',
 		'aioprometheus[aiohttp] >= 20.0',

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
 	},
 	zip_safe = False,
 	install_requires = [
-		'starlette >= 0.14, < 0.16',
+		'starlette >= 0.14, < 0.15',
 		'uvicorn >= 0.13',
 		'dacite >= 1.5.1',
 		'aioprometheus[aiohttp] >= 20.0',


### PR DESCRIPTION
Ok, so I got tired of later Starlette versions doing screwy things to our middleware :D I've pinned it to 0.14.x for now. I've also simplified our error handling - it's now all funneled through the `JSONErrorMiddleware`.

The issue with the built-in error handlers was that our Prom middleware wasn't being correctly informed of status codes for responses, so _everything_ looks fine when say, visualising in Grafana.

Longer-term, I'm going to see if there's a _less_ featureful replacement for Starlette - Govyn is quite opinionated and that doesn't necessarily play well with larger frameworks.